### PR TITLE
[phx.gen.live] Extract Fixtures module

### DIFF
--- a/test/demo_live_app/blog_test.exs
+++ b/test/demo_live_app/blog_test.exs
@@ -4,9 +4,13 @@ defmodule DemoLiveApp.BlogTest do
   alias DemoLiveApp.Blog
 
   describe "posts" do
+    alias DemoLiveApp.Blog.Post
+
     import DemoLiveApp.BlogFixtures
 
-    alias DemoLiveApp.Blog.Post
+    @valid_attrs %{body: "some body", rating: 42, title: "some title"}
+    @update_attrs %{body: "some updated body", rating: 43, title: "some updated title"}
+    @invalid_attrs %{body: nil, rating: nil, title: nil}
 
     test "list_posts/0 returns all posts" do
       post = post_fixture()
@@ -19,37 +23,27 @@ defmodule DemoLiveApp.BlogTest do
     end
 
     test "create_post/1 with valid data creates a post" do
-      post_attrs = post_attrs_fixture()
-
-      assert {:ok, %Post{} = post} = Blog.create_post(post_attrs)
-
-      assert post.body == post_attrs.body
-      assert post.rating == post_attrs.rating
-      assert post.title == post_attrs.title
+      assert {:ok, %Post{} = post} = Blog.create_post(@valid_attrs)
+      assert post.body == "some body"
+      assert post.rating == 42
+      assert post.title == "some title"
     end
 
     test "create_post/1 with invalid data returns error changeset" do
-      assert {:error, changeset} = Blog.create_post(invalid_post_attrs_fixture())
-
-      assert %{body: ["can't be blank"]} = errors_on(changeset)
-      assert %{rating: ["can't be blank"]} = errors_on(changeset)
-      assert %{title: ["can't be blank"]} = errors_on(changeset)
+      assert {:error, %Ecto.Changeset{}} = Blog.create_post(@invalid_attrs)
     end
 
     test "update_post/2 with valid data updates the post" do
       post = post_fixture()
-      update_attrs = update_post_attrs_fixture()
-
       assert {:ok, %Post{} = post} = Blog.update_post(post, @update_attrs)
-
-      assert post.body == update_attrs.body
-      assert post.rating == update_attrs.rating
-      assert post.title == update_attrs.title
+      assert post.body == "some updated body"
+      assert post.rating == 43
+      assert post.title == "some updated title"
     end
 
     test "update_post/2 with invalid data returns error changeset" do
       post = post_fixture()
-      assert {:error, %Ecto.Changeset{}} = Blog.update_post(post, invalid_post_attrs_fixture())
+      assert {:error, %Ecto.Changeset{}} = Blog.update_post(post, @invalid_attrs)
       assert post == Blog.get_post!(post.id)
     end
 
@@ -60,11 +54,8 @@ defmodule DemoLiveApp.BlogTest do
     end
 
     test "change_post/1 returns a post changeset" do
-      assert %Ecto.Changeset{} = changeset = Blog.change_post(%Post{})
-
-      assert %{body: ["can't be blank"]} = errors_on(changeset)
-      assert %{rating: ["can't be blank"]} = errors_on(changeset)
-      assert %{title: ["can't be blank"]} = errors_on(changeset)
+      post = post_fixture()
+      assert %Ecto.Changeset{} = Blog.change_post(post)
     end
   end
 end

--- a/test/demo_live_app/blog_test.exs
+++ b/test/demo_live_app/blog_test.exs
@@ -4,20 +4,9 @@ defmodule DemoLiveApp.BlogTest do
   alias DemoLiveApp.Blog
 
   describe "posts" do
+    import DemoLiveApp.BlogFixtures
+
     alias DemoLiveApp.Blog.Post
-
-    @valid_attrs %{body: "some body", rating: 42, title: "some title"}
-    @update_attrs %{body: "some updated body", rating: 43, title: "some updated title"}
-    @invalid_attrs %{body: nil, rating: nil, title: nil}
-
-    def post_fixture(attrs \\ %{}) do
-      {:ok, post} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Blog.create_post()
-
-      post
-    end
 
     test "list_posts/0 returns all posts" do
       post = post_fixture()
@@ -30,27 +19,37 @@ defmodule DemoLiveApp.BlogTest do
     end
 
     test "create_post/1 with valid data creates a post" do
-      assert {:ok, %Post{} = post} = Blog.create_post(@valid_attrs)
-      assert post.body == "some body"
-      assert post.rating == 42
-      assert post.title == "some title"
+      post_attrs = post_attrs_fixture()
+
+      assert {:ok, %Post{} = post} = Blog.create_post(post_attrs)
+
+      assert post.body == post_attrs.body
+      assert post.rating == post_attrs.rating
+      assert post.title == post_attrs.title
     end
 
     test "create_post/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Blog.create_post(@invalid_attrs)
+      assert {:error, changeset} = Blog.create_post(invalid_post_attrs_fixture())
+
+      assert %{body: ["can't be blank"]} = errors_on(changeset)
+      assert %{rating: ["can't be blank"]} = errors_on(changeset)
+      assert %{title: ["can't be blank"]} = errors_on(changeset)
     end
 
     test "update_post/2 with valid data updates the post" do
       post = post_fixture()
+      update_attrs = update_post_attrs_fixture()
+
       assert {:ok, %Post{} = post} = Blog.update_post(post, @update_attrs)
-      assert post.body == "some updated body"
-      assert post.rating == 43
-      assert post.title == "some updated title"
+
+      assert post.body == update_attrs.body
+      assert post.rating == update_attrs.rating
+      assert post.title == update_attrs.title
     end
 
     test "update_post/2 with invalid data returns error changeset" do
       post = post_fixture()
-      assert {:error, %Ecto.Changeset{}} = Blog.update_post(post, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Blog.update_post(post, invalid_post_attrs_fixture())
       assert post == Blog.get_post!(post.id)
     end
 
@@ -61,8 +60,11 @@ defmodule DemoLiveApp.BlogTest do
     end
 
     test "change_post/1 returns a post changeset" do
-      post = post_fixture()
-      assert %Ecto.Changeset{} = Blog.change_post(post)
+      assert %Ecto.Changeset{} = changeset = Blog.change_post(%Post{})
+
+      assert %{body: ["can't be blank"]} = errors_on(changeset)
+      assert %{rating: ["can't be blank"]} = errors_on(changeset)
+      assert %{title: ["can't be blank"]} = errors_on(changeset)
     end
   end
 end

--- a/test/demo_live_app/blog_test.exs
+++ b/test/demo_live_app/blog_test.exs
@@ -8,8 +8,6 @@ defmodule DemoLiveApp.BlogTest do
 
     import DemoLiveApp.BlogFixtures
 
-    @valid_attrs %{body: "some body", rating: 42, title: "some title"}
-    @update_attrs %{body: "some updated body", rating: 43, title: "some updated title"}
     @invalid_attrs %{body: nil, rating: nil, title: nil}
 
     test "list_posts/0 returns all posts" do
@@ -23,7 +21,10 @@ defmodule DemoLiveApp.BlogTest do
     end
 
     test "create_post/1 with valid data creates a post" do
-      assert {:ok, %Post{} = post} = Blog.create_post(@valid_attrs)
+      valid_attrs = %{body: "some body", rating: 42, title: "some title"}
+
+      assert {:ok, %Post{} = post} = Blog.create_post(valid_attrs)
+
       assert post.body == "some body"
       assert post.rating == 42
       assert post.title == "some title"
@@ -35,7 +36,10 @@ defmodule DemoLiveApp.BlogTest do
 
     test "update_post/2 with valid data updates the post" do
       post = post_fixture()
-      assert {:ok, %Post{} = post} = Blog.update_post(post, @update_attrs)
+      update_attrs = %{body: "some updated body", rating: 43, title: "some updated title"}
+
+      assert {:ok, %Post{} = post} = Blog.update_post(post, update_attrs)
+
       assert post.body == "some updated body"
       assert post.rating == 43
       assert post.title == "some updated title"

--- a/test/demo_live_app_web/live/post_live_test.exs
+++ b/test/demo_live_app_web/live/post_live_test.exs
@@ -2,11 +2,17 @@ defmodule DemoLiveAppWeb.PostLiveTest do
   use DemoLiveAppWeb.ConnCase
 
   import Phoenix.LiveViewTest
-
   import DemoLiveApp.BlogFixtures
 
+  alias DemoLiveApp.Blog
+
+  @create_attrs %{body: "some body", rating: 42, title: "some title"}
+  @update_attrs %{body: "some updated body", rating: 43, title: "some updated title"}
+  @invalid_attrs %{body: nil, rating: nil, title: nil}
+
   defp create_post(_) do
-    %{post: post_fixture()}
+    post = post_fixture()
+    %{post: post}
   end
 
   describe "Index" do
@@ -28,12 +34,12 @@ defmodule DemoLiveAppWeb.PostLiveTest do
       assert_patch(index_live, Routes.post_index_path(conn, :new))
 
       assert index_live
-             |> form("#post-form", post: invalid_post_attrs_fixture())
+             |> form("#post-form", post: @invalid_attrs)
              |> render_change() =~ "can&apos;t be blank"
 
       {:ok, _, html} =
         index_live
-        |> form("#post-form", post: post_attrs_fixture())
+        |> form("#post-form", post: @create_attrs)
         |> render_submit()
         |> follow_redirect(conn, Routes.post_index_path(conn, :index))
 
@@ -50,12 +56,12 @@ defmodule DemoLiveAppWeb.PostLiveTest do
       assert_patch(index_live, Routes.post_index_path(conn, :edit, post))
 
       assert index_live
-             |> form("#post-form", post: invalid_post_attrs_fixture())
+             |> form("#post-form", post: @invalid_attrs)
              |> render_change() =~ "can&apos;t be blank"
 
       {:ok, _, html} =
         index_live
-        |> form("#post-form", post: update_post_attrs_fixture())
+        |> form("#post-form", post: @update_attrs)
         |> render_submit()
         |> follow_redirect(conn, Routes.post_index_path(conn, :index))
 
@@ -90,12 +96,12 @@ defmodule DemoLiveAppWeb.PostLiveTest do
       assert_patch(show_live, Routes.post_show_path(conn, :edit, post))
 
       assert show_live
-             |> form("#post-form", post: invalid_post_attrs_fixture())
+             |> form("#post-form", post: @invalid_attrs)
              |> render_change() =~ "can&apos;t be blank"
 
       {:ok, _, html} =
         show_live
-        |> form("#post-form", post: update_post_attrs_fixture())
+        |> form("#post-form", post: @update_attrs)
         |> render_submit()
         |> follow_redirect(conn, Routes.post_show_path(conn, :show, post))
 

--- a/test/demo_live_app_web/live/post_live_test.exs
+++ b/test/demo_live_app_web/live/post_live_test.exs
@@ -3,20 +3,10 @@ defmodule DemoLiveAppWeb.PostLiveTest do
 
   import Phoenix.LiveViewTest
 
-  alias DemoLiveApp.Blog
-
-  @create_attrs %{body: "some body", rating: 42, title: "some title"}
-  @update_attrs %{body: "some updated body", rating: 43, title: "some updated title"}
-  @invalid_attrs %{body: nil, rating: nil, title: nil}
-
-  defp fixture(:post) do
-    {:ok, post} = Blog.create_post(@create_attrs)
-    post
-  end
+  import DemoLiveApp.BlogFixtures
 
   defp create_post(_) do
-    post = fixture(:post)
-    %{post: post}
+    %{post: post_fixture()}
   end
 
   describe "Index" do
@@ -38,12 +28,12 @@ defmodule DemoLiveAppWeb.PostLiveTest do
       assert_patch(index_live, Routes.post_index_path(conn, :new))
 
       assert index_live
-             |> form("#post-form", post: @invalid_attrs)
+             |> form("#post-form", post: invalid_post_attrs_fixture())
              |> render_change() =~ "can&apos;t be blank"
 
       {:ok, _, html} =
         index_live
-        |> form("#post-form", post: @create_attrs)
+        |> form("#post-form", post: post_attrs_fixture())
         |> render_submit()
         |> follow_redirect(conn, Routes.post_index_path(conn, :index))
 
@@ -60,12 +50,12 @@ defmodule DemoLiveAppWeb.PostLiveTest do
       assert_patch(index_live, Routes.post_index_path(conn, :edit, post))
 
       assert index_live
-             |> form("#post-form", post: @invalid_attrs)
+             |> form("#post-form", post: invalid_post_attrs_fixture())
              |> render_change() =~ "can&apos;t be blank"
 
       {:ok, _, html} =
         index_live
-        |> form("#post-form", post: @update_attrs)
+        |> form("#post-form", post: update_post_attrs_fixture())
         |> render_submit()
         |> follow_redirect(conn, Routes.post_index_path(conn, :index))
 
@@ -100,12 +90,12 @@ defmodule DemoLiveAppWeb.PostLiveTest do
       assert_patch(show_live, Routes.post_show_path(conn, :edit, post))
 
       assert show_live
-             |> form("#post-form", post: @invalid_attrs)
+             |> form("#post-form", post: invalid_post_attrs_fixture())
              |> render_change() =~ "can&apos;t be blank"
 
       {:ok, _, html} =
         show_live
-        |> form("#post-form", post: @update_attrs)
+        |> form("#post-form", post: update_post_attrs_fixture())
         |> render_submit()
         |> follow_redirect(conn, Routes.post_show_path(conn, :show, post))
 

--- a/test/support/fixtures/blog_fixtures.ex
+++ b/test/support/fixtures/blog_fixtures.ex
@@ -1,0 +1,38 @@
+defmodule DemoLiveApp.BlogFixtures do
+  def valid_post_body, do: "some body"
+  def valid_post_rating, do: 42
+  def valid_post_title, do: "some title"
+
+  def post_fixture(attrs \\ %{}) do
+    {:ok, post} =
+      attrs
+      |> post_attrs_fixture()
+      |> DemoLiveApp.Blog.create_post()
+
+    post
+  end
+
+  def post_attrs_fixture(attrs \\ %{}) do
+    Enum.into(attrs, %{
+      body: valid_post_body(),
+      rating: valid_post_rating(),
+      title: valid_post_title()
+    })
+  end
+
+  def update_post_attrs_fixture(attrs \\ %{}) do
+    Enum.into(attrs, %{
+      body: "some updated body",
+      rating: 43,
+      title: "some updated title"
+    })
+  end
+
+  def invalid_post_attrs_fixture(attrs \\ %{}) do
+    Enum.into(attrs, %{
+      body: nil,
+      rating: nil,
+      title: nil
+    })
+  end
+end

--- a/test/support/fixtures/blog_fixtures.ex
+++ b/test/support/fixtures/blog_fixtures.ex
@@ -1,38 +1,14 @@
 defmodule DemoLiveApp.BlogFixtures do
-  def valid_post_body, do: "some body"
-  def valid_post_rating, do: 42
-  def valid_post_title, do: "some title"
-
   def post_fixture(attrs \\ %{}) do
     {:ok, post} =
       attrs
-      |> post_attrs_fixture()
+      |> Enum.into(%{
+        body: "some body",
+        rating: 42,
+        title: "some title"
+      })
       |> DemoLiveApp.Blog.create_post()
 
     post
-  end
-
-  def post_attrs_fixture(attrs \\ %{}) do
-    Enum.into(attrs, %{
-      body: valid_post_body(),
-      rating: valid_post_rating(),
-      title: valid_post_title()
-    })
-  end
-
-  def update_post_attrs_fixture(attrs \\ %{}) do
-    Enum.into(attrs, %{
-      body: "some updated body",
-      rating: 43,
-      title: "some updated title"
-    })
-  end
-
-  def invalid_post_attrs_fixture(attrs \\ %{}) do
-    Enum.into(attrs, %{
-      body: nil,
-      rating: nil,
-      title: nil
-    })
   end
 end


### PR DESCRIPTION
I'd like to get some feedback on these proposed updates to the `phx.gen.live` generators for 
https://github.com/phoenixframework/phoenix/issues/3797. The goal of this is to extract a `<Context>Fixtures` module into `test/support/fixtures` with functions that could be used throughout the test suite.

I'm not sure if extracting separate `*_attrs` functions in the Fixtures module is the way to go, but it does consolidate the `*_attrs` module variables in the different tests.